### PR TITLE
Add AnimationSystem and Sprite3dSystem system sets

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,4 +1,7 @@
-use bevy::app::{App, Plugin, PostUpdate};
+use bevy::{
+    app::{App, Plugin, PostUpdate},
+    prelude::{IntoSystemConfigs, SystemSet},
+};
 
 use crate::{
     animator::SpritesheetAnimator,
@@ -43,6 +46,14 @@ use crate::{
 /// ```
 pub struct SpritesheetAnimationPlugin;
 
+/// Label for systems that update the animation state.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
+pub struct AnimationSystem;
+
+/// Label for systems that update the sprite state.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
+pub struct Sprite3dSystem;
+
 impl Plugin for SpritesheetAnimationPlugin {
     fn build(&self, app: &mut App) {
         app
@@ -59,11 +70,15 @@ impl Plugin for SpritesheetAnimationPlugin {
                 PostUpdate,
                 (
                     // Main animation system
-                    spritesheet_animation::play_animations,
+                    spritesheet_animation::play_animations.in_set(AnimationSystem),
                     // 3D sprite systems
-                    sprite3d::setup_rendering,
-                    sprite3d::sync_sprites_with_component,
-                    sprite3d::sync_sprites_with_atlas,
+                    (
+                        sprite3d::setup_rendering,
+                        sprite3d::sync_sprites_with_component,
+                        sprite3d::sync_sprites_with_atlas,
+                    )
+                        .in_set(Sprite3dSystem)
+                        .after(AnimationSystem),
                 ),
             );
     }


### PR DESCRIPTION
The animation system updates `texture_atlas.index`. The sprite3d systems operate on `texture_atlas.index`. So I think that the sprite3d systems should run after animation.

This manifests in my project as me needing this system ordering:

  - In `Update`, I am changing the animation of my entity.
  - In `PostUpdate`, I am setting the `Sprite3D` `anchor` and `custom_size` but these values must be obtained from the current animation frame, and that requires using `texture_atlas.index`. This means this system needs to run after `AnimationSystem`. But it also needs to run before `Sprite3dSystem` because I am setting `anchor` and `custom_size` which `Sprite3dSystem` of course is looking at.

In project the use looks something like this:

```rust
app.add_systems(
    Update,
    update_animations,
    .run_if(in_state(AppState::MyState)),
);

app.add_systems(
    PostUpdate,
    update_anchor_and_size
        .after(AnimationSystem)
        .before(Sprite3dSystem)
        .run_if(in_state(AppState::MyState)),
);
```