### PR TITLE
Make system sets public

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -12,11 +12,11 @@ use crate::{
 
 /// Set for systems that update the animation state.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
-struct AnimationSystemSet;
+pub struct AnimationSystemSet;
 
 /// Set for systems that update the sprite state.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
-struct Sprite3dSystemSet;
+pub struct Sprite3dSystemSet;
 
 /// The spritesheet animation plugin to add to Bevy apps.
 ///


### PR DESCRIPTION
So I can do something like this:

```rust
app.add_systems(
  PostUpdate,
  update_my_sprites_anchor_and_size
    .after(AnimationSystemSet)
    .before(Sprite3dSystemSet),
);
```

To keep my system ordered correctly with `bevy_spritesheet_animation`.

Note: These seemed to have been made private in a cleanup commit, possibly accidentally?