### PR TITLE
add get_clip_name, get_animation_name, get_marker_name method in library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ inherits = "release"
 [[bench]]
 name = "basic"
 harness = false
+
+[lints]
+clippy.type_complexity = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,19 @@ name = "bevy_spritesheet_animation"
 version = "0.4.3"
 description = "A Bevy plugin for animating sprites"
 repository = "https://github.com/merwaaan/bevy_spritesheet_animation"
-readme="README.md"
+readme = "README.md"
 license = "MIT"
 keywords = ["bevy", "sprite", "animation"]
 categories = ["game-development"]
 edition = "2021"
 resolver = "2"
-exclude = [
-  "assets/example.gif",
-  "assets/example3d.gif"
-]
+exclude = ["assets/example.gif", "assets/example3d.gif"]
 
 [dependencies]
-bevy = { version = "0.14.0", default-features = false, features = ["bevy_pbr", "bevy_sprite"] }
+bevy = { version = "0.14.0", default-features = false, features = [
+  "bevy_pbr",
+  "bevy_sprite",
+] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/library.rs
+++ b/src/library.rs
@@ -132,11 +132,11 @@ impl AnimationLibrary {
     pub fn name_clip(
         &mut self,
         clip_id: ClipId,
-        name: impl AsRef<str>,
+        name: impl Into<String>,
     ) -> Result<(), LibraryError> {
-        let name = name.as_ref();
+        let name = name.into();
 
-        if let Some(existing_clip_id) = self.clip_with_name(name) {
+        if let Some(existing_clip_id) = self.clip_with_name(&name) {
             // The clip already has this name: no-op
             if existing_clip_id == clip_id {
                 Ok(())
@@ -144,7 +144,7 @@ impl AnimationLibrary {
                 Err(LibraryError::NameAlreadyTaken)
             }
         } else {
-            self.clip_name_lookup.insert(clip_id, name.to_string());
+            self.clip_name_lookup.insert(clip_id, name);
             Ok(())
         }
     }
@@ -293,11 +293,11 @@ impl AnimationLibrary {
     pub fn name_animation(
         &mut self,
         animation_id: AnimationId,
-        name: impl AsRef<str>,
+        name: impl Into<String>,
     ) -> Result<(), LibraryError> {
-        let name = name.as_ref();
+        let name = name.into();
 
-        if let Some(existing_animation_id) = self.animation_with_name(name) {
+        if let Some(existing_animation_id) = self.animation_with_name(&name) {
             // The animation already has this name: no-op
             if existing_animation_id == animation_id {
                 Ok(())
@@ -305,8 +305,7 @@ impl AnimationLibrary {
                 Err(LibraryError::NameAlreadyTaken)
             }
         } else {
-            self.animation_name_lookup
-                .insert(animation_id, name.to_string());
+            self.animation_name_lookup.insert(animation_id, name);
             Ok(())
         }
     }
@@ -425,11 +424,11 @@ impl AnimationLibrary {
     pub fn name_marker(
         &mut self,
         marker_id: AnimationMarkerId,
-        name: impl AsRef<str>,
+        name: impl Into<String>,
     ) -> Result<(), LibraryError> {
-        let name = name.as_ref();
+        let name = name.into();
 
-        if let Some(existing_marker_id) = self.marker_with_name(name) {
+        if let Some(existing_marker_id) = self.marker_with_name(&name) {
             // The marker already has this name: no-op
             if existing_marker_id == marker_id {
                 Ok(())
@@ -437,7 +436,7 @@ impl AnimationLibrary {
                 Err(LibraryError::NameAlreadyTaken)
             }
         } else {
-            self.marker_name_lookup.insert(marker_id, name.to_string());
+            self.marker_name_lookup.insert(marker_id, name);
             Ok(())
         }
     }

--- a/src/library.rs
+++ b/src/library.rs
@@ -169,6 +169,21 @@ impl AnimationLibrary {
         })
     }
 
+    /// Returns the name of the clip with the given ID if it exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `clip_id` - the clip id
+    pub fn get_clip_name(&self, clip_id: ClipId) -> Option<&str> {
+        self.clip_name_lookup.iter().find_map(|(k, v)| {
+            if k == &clip_id {
+                Some(v.as_str())
+            } else {
+                None
+            }
+        })
+    }
+
     /// Returns true if a clip has the given name.
     ///
     /// # Arguments
@@ -318,6 +333,21 @@ impl AnimationLibrary {
         )
     }
 
+    /// Returns the name of the animation with the given ID if it exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `animation_id` - the animation id
+    pub fn get_animation_name(&self, animation_id: AnimationId) -> Option<&str> {
+        self.animation_name_lookup.iter().find_map(|(k, v)| {
+            if k == &animation_id {
+                Some(v.as_str())
+            } else {
+                None
+            }
+        })
+    }
+
     /// Returns true if an animation has the given name.
     ///
     /// # Arguments
@@ -426,6 +456,21 @@ impl AnimationLibrary {
         self.marker_name_lookup.iter().find_map(|(k, v)| {
             if v.as_str() == name.as_ref() {
                 Some(*k)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns the name of the marker with the given ID if it exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `marker_id` - the marker id
+    pub fn get_marker_name(&self, marker_id: AnimationMarkerId) -> Option<&str> {
+        self.marker_name_lookup.iter().find_map(|(k, v)| {
+            if k == &marker_id {
+                Some(v.as_str())
             } else {
                 None
             }

--- a/tests/names.rs
+++ b/tests/names.rs
@@ -13,6 +13,7 @@ fn clips() {
     let clip1_id = ctx.library().register_clip(clip1);
 
     assert!(!ctx.library().is_clip_name(clip1_id, "first"));
+    assert_eq!(ctx.library().get_clip_name(clip1_id), None);
     assert_eq!(ctx.library().clip_with_name("first"), None);
     assert_eq!(ctx.library().clip_names().len(), 0);
 
@@ -21,6 +22,7 @@ fn clips() {
     assert!(ctx.library().name_clip(clip1_id, "first").is_ok());
 
     assert!(ctx.library().is_clip_name(clip1_id, "first"));
+    assert_eq!(ctx.library().get_clip_name(clip1_id), Some("first"));
     assert_eq!(ctx.library().clip_with_name("first"), Some(clip1_id));
 
     assert_eq!(ctx.library().clip_names().len(), 1);
@@ -34,6 +36,7 @@ fn clips() {
     assert!(ctx.library().name_clip(clip1_id, "first again").is_ok());
 
     assert!(ctx.library().is_clip_name(clip1_id, "first again"));
+    assert_eq!(ctx.library().get_clip_name(clip1_id), Some("first again"));
     assert_eq!(ctx.library().clip_with_name("first again"), Some(clip1_id));
 
     assert_eq!(ctx.library().clip_names().len(), 1);
@@ -48,7 +51,7 @@ fn clips() {
 
     assert!(ctx.library().name_clip(clip1_id, "first").is_ok());
 
-    // Create another marker and reuse the name, this should not work
+    // Create another clip and reuse the name, this should not work
 
     let clip2 = Clip::from_frames([]);
     let clip2_id = ctx.library().register_clip(clip2);
@@ -59,9 +62,11 @@ fn clips() {
     ));
 
     assert!(!ctx.library().is_clip_name(clip2_id, "first"));
+    assert_eq!(ctx.library().get_clip_name(clip2_id), None);
 
     assert_eq!(ctx.library().clip_with_name("first"), Some(clip1_id));
     assert!(ctx.library().is_clip_name(clip1_id, "first"));
+    assert_eq!(ctx.library().get_clip_name(clip1_id), Some("first"));
 
     assert_eq!(ctx.library().clip_names().len(), 1);
 }
@@ -76,6 +81,7 @@ fn animations() {
     let animation1_id = ctx.library().register_animation(animation1);
 
     assert!(!ctx.library().is_animation_name(animation1_id, "first"));
+    assert_eq!(ctx.library().get_animation_name(animation1_id), None);
     assert_eq!(ctx.library().animation_with_name("first"), None);
     assert_eq!(ctx.library().animation_names().len(), 0);
 
@@ -84,6 +90,10 @@ fn animations() {
     assert!(ctx.library().name_animation(animation1_id, "first").is_ok());
 
     assert!(ctx.library().is_animation_name(animation1_id, "first"));
+    assert_eq!(
+        ctx.library().get_animation_name(animation1_id),
+        Some("first")
+    );
     assert_eq!(
         ctx.library().animation_with_name("first"),
         Some(animation1_id)
@@ -108,6 +118,10 @@ fn animations() {
     assert!(ctx
         .library()
         .is_animation_name(animation1_id, "first again"));
+    assert_eq!(
+        ctx.library().get_animation_name(animation1_id),
+        Some("first again")
+    );
     assert_eq!(
         ctx.library().animation_with_name("first again"),
         Some(animation1_id)
@@ -139,12 +153,17 @@ fn animations() {
     ));
 
     assert!(!ctx.library().is_animation_name(anim2_id, "first"));
+    assert_eq!(ctx.library().get_animation_name(anim2_id), None);
 
     assert_eq!(
         ctx.library().animation_with_name("first"),
         Some(animation1_id)
     );
     assert!(ctx.library().is_animation_name(animation1_id, "first"));
+    assert_eq!(
+        ctx.library().get_animation_name(animation1_id),
+        Some("first")
+    );
 
     assert_eq!(ctx.library().animation_names().len(), 1);
 }
@@ -158,6 +177,7 @@ fn markers() {
     let marker1 = ctx.library().new_marker();
 
     assert!(!ctx.library().is_marker_name(marker1, "first"));
+    assert_eq!(ctx.library().get_marker_name(marker1), None);
     assert_eq!(ctx.library().marker_with_name("first"), None);
     assert_eq!(ctx.library().marker_names().len(), 0);
 
@@ -166,6 +186,7 @@ fn markers() {
     assert!(ctx.library().name_marker(marker1, "first").is_ok());
 
     assert!(ctx.library().is_marker_name(marker1, "first"));
+    assert_eq!(ctx.library().get_marker_name(marker1), Some("first"));
     assert_eq!(ctx.library().marker_with_name("first"), Some(marker1));
 
     assert_eq!(ctx.library().marker_names().len(), 1);
@@ -182,6 +203,7 @@ fn markers() {
     assert!(ctx.library().name_marker(marker1, "first again").is_ok());
 
     assert!(ctx.library().is_marker_name(marker1, "first again"));
+    assert_eq!(ctx.library().get_marker_name(marker1), Some("first again"));
     assert_eq!(ctx.library().marker_with_name("first again"), Some(marker1));
 
     assert_eq!(ctx.library().marker_names().len(), 1);
@@ -209,9 +231,11 @@ fn markers() {
     ));
 
     assert!(!ctx.library().is_marker_name(marker2, "first"));
+    assert_eq!(ctx.library().get_marker_name(marker2), None);
 
     assert_eq!(ctx.library().marker_with_name("first"), Some(marker1));
     assert!(ctx.library().is_marker_name(marker1, "first"));
+    assert_eq!(ctx.library().get_marker_name(marker1), Some("first"));
 
     assert_eq!(ctx.library().marker_names().len(), 1);
 }

--- a/tests/names.rs
+++ b/tests/names.rs
@@ -25,36 +25,30 @@ fn clips() {
 
     assert_eq!(ctx.library().clip_names().len(), 1);
     assert_eq!(
-        ctx.library().clip_names().get("first").copied(),
-        Some(clip1_id)
+        ctx.library().clip_names().get(&clip1_id).map(AsRef::as_ref),
+        Some("first")
     );
 
-    // Give it a second name, this is not forbidden
+    // Name it again, replacing the old name
 
     assert!(ctx.library().name_clip(clip1_id, "first again").is_ok());
-
-    assert!(ctx.library().is_clip_name(clip1_id, "first"));
-    assert_eq!(ctx.library().clip_with_name("first"), Some(clip1_id));
 
     assert!(ctx.library().is_clip_name(clip1_id, "first again"));
     assert_eq!(ctx.library().clip_with_name("first again"), Some(clip1_id));
 
-    assert_eq!(ctx.library().clip_names().len(), 2);
+    assert_eq!(ctx.library().clip_names().len(), 1);
     assert_eq!(
-        ctx.library().clip_names().get("first").copied(),
-        Some(clip1_id)
+        ctx.library().clip_names().get(&clip1_id).map(AsRef::as_ref),
+        Some("first again")
     );
-    assert_eq!(
-        ctx.library().clip_names().get("first again").copied(),
-        Some(clip1_id)
-    );
+
+    assert!(ctx.library().name_clip(clip1_id, "first").is_ok());
 
     // Give it the same names again, this is a no-op
 
     assert!(ctx.library().name_clip(clip1_id, "first").is_ok());
-    assert!(ctx.library().name_clip(clip1_id, "first again").is_ok());
 
-    // Create another marker and reuse one of those names, this should not work
+    // Create another marker and reuse the name, this should not work
 
     let clip2 = Clip::from_frames([]);
     let clip2_id = ctx.library().register_clip(clip2);
@@ -69,7 +63,7 @@ fn clips() {
     assert_eq!(ctx.library().clip_with_name("first"), Some(clip1_id));
     assert!(ctx.library().is_clip_name(clip1_id, "first"));
 
-    assert_eq!(ctx.library().clip_names().len(), 2);
+    assert_eq!(ctx.library().clip_names().len(), 1);
 }
 
 #[test]
@@ -97,22 +91,19 @@ fn animations() {
 
     assert_eq!(ctx.library().animation_names().len(), 1);
     assert_eq!(
-        ctx.library().animation_names().get("first").copied(),
-        Some(animation1_id)
+        ctx.library()
+            .animation_names()
+            .get(&animation1_id)
+            .map(AsRef::as_ref),
+        Some("first")
     );
 
-    // Give it a second name, this is not forbidden
+    // Name it again, replacing the old name
 
     assert!(ctx
         .library()
         .name_animation(animation1_id, "first again")
         .is_ok());
-
-    assert!(ctx.library().is_animation_name(animation1_id, "first"));
-    assert_eq!(
-        ctx.library().animation_with_name("first"),
-        Some(animation1_id)
-    );
 
     assert!(ctx
         .library()
@@ -122,25 +113,22 @@ fn animations() {
         Some(animation1_id)
     );
 
-    assert_eq!(ctx.library().animation_names().len(), 2);
+    assert_eq!(ctx.library().animation_names().len(), 1);
     assert_eq!(
-        ctx.library().animation_names().get("first").copied(),
-        Some(animation1_id)
+        ctx.library()
+            .animation_names()
+            .get(&animation1_id)
+            .map(AsRef::as_ref),
+        Some("first again")
     );
-    assert_eq!(
-        ctx.library().animation_names().get("first again").copied(),
-        Some(animation1_id)
-    );
+
+    assert!(ctx.library().name_animation(animation1_id, "first").is_ok());
 
     // Give it the same names again, this is a no-op
 
     assert!(ctx.library().name_animation(animation1_id, "first").is_ok());
-    assert!(ctx
-        .library()
-        .name_animation(animation1_id, "first again")
-        .is_ok());
 
-    // Create another animation and reuse one of those names, this should not work
+    // Create another animation and reuse the name, this should not work
 
     let anim2 = Animation::from_clips([]);
     let anim2_id = ctx.library().register_animation(anim2);
@@ -158,7 +146,7 @@ fn animations() {
     );
     assert!(ctx.library().is_animation_name(animation1_id, "first"));
 
-    assert_eq!(ctx.library().animation_names().len(), 2);
+    assert_eq!(ctx.library().animation_names().len(), 1);
 }
 
 #[test]
@@ -182,36 +170,36 @@ fn markers() {
 
     assert_eq!(ctx.library().marker_names().len(), 1);
     assert_eq!(
-        ctx.library().marker_names().get("first").copied(),
-        Some(marker1)
+        ctx.library()
+            .marker_names()
+            .get(&marker1)
+            .map(AsRef::as_ref),
+        Some("first")
     );
 
-    // Give it a second name, this is not forbidden
+    // Name it again, replacing the old name
 
     assert!(ctx.library().name_marker(marker1, "first again").is_ok());
-
-    assert!(ctx.library().is_marker_name(marker1, "first"));
-    assert_eq!(ctx.library().marker_with_name("first"), Some(marker1));
 
     assert!(ctx.library().is_marker_name(marker1, "first again"));
     assert_eq!(ctx.library().marker_with_name("first again"), Some(marker1));
 
-    assert_eq!(ctx.library().marker_names().len(), 2);
+    assert_eq!(ctx.library().marker_names().len(), 1);
     assert_eq!(
-        ctx.library().marker_names().get("first").copied(),
-        Some(marker1)
+        ctx.library()
+            .marker_names()
+            .get(&marker1)
+            .map(AsRef::as_ref),
+        Some("first again")
     );
-    assert_eq!(
-        ctx.library().marker_names().get("first again").copied(),
-        Some(marker1)
-    );
+
+    assert!(ctx.library().name_marker(marker1, "first").is_ok());
 
     // Give it the same names again, this is a no-op
 
     assert!(ctx.library().name_marker(marker1, "first").is_ok());
-    assert!(ctx.library().name_marker(marker1, "first again").is_ok());
 
-    // Create another marker and reuse one of those names, this should not work
+    // Create another marker and reuse the name, this should not work
 
     let marker2 = ctx.library().new_marker();
 
@@ -225,5 +213,5 @@ fn markers() {
     assert_eq!(ctx.library().marker_with_name("first"), Some(marker1));
     assert!(ctx.library().is_marker_name(marker1, "first"));
 
-    assert_eq!(ctx.library().marker_names().len(), 2);
+    assert_eq!(ctx.library().marker_names().len(), 1);
 }

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -8,11 +8,7 @@ use context::*;
 fn library_available_as_a_resource() {
     let ctx = Context::new();
 
-    assert!(ctx
-        .app
-        .world()
-        .get_resource::<AnimationLibrary>()
-        .is_some());
+    assert!(ctx.app.world().get_resource::<AnimationLibrary>().is_some());
 }
 
 #[test]


### PR DESCRIPTION
i have also replaced the `impl Into<String>` by `impl AsRef<str>` since not all method always need a owned String, and 90% of the time a &str suffice. This allows the users and our methods to not have to clone everything even when not needed, and so its a gain in performance and memory usage.

i've also ran cargo fmt, and allowed the type complexity clippy lint for bevy's systems.

this implement everything discussed in #18, and so it close #18 