### PR TITLE
add a plugin option to disable 3d systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Add the plugin to enable animations.
         // This makes the AnimationLibrary resource available to your systems.
-        .add_plugins(SpritesheetAnimationPlugin)
+        .add_plugins(SpritesheetAnimationPlugin::default())
         .add_systems(Startup, setup)
         .run();
 }

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -25,7 +25,7 @@ fn create_app() -> App {
                 .into(),
                 ..default()
             }),
-        SpritesheetAnimationPlugin,
+        SpritesheetAnimationPlugin::default(),
     ))
     .finish();
     app
@@ -71,10 +71,7 @@ fn playback(bencher: Bencher, (animation_count, sprite_count): (usize, usize)) {
 
     let mut rng = rand::thread_rng();
     for _ in 0..sprite_count {
-        create_sprite(
-            &mut app,
-            animation_ids.iter().choose(&mut rng).unwrap().clone(),
-        );
+        create_sprite(&mut app, *animation_ids.iter().choose(&mut rng).unwrap());
     }
 
     let mut time = Time::new_with(());
@@ -83,7 +80,7 @@ fn playback(bencher: Bencher, (animation_count, sprite_count): (usize, usize)) {
         Res<AnimationLibrary>,
         ResMut<Animator>,
         EventWriter<AnimationEvent>,
-        Query<(Entity, &mut SpritesheetAnimation, &mut TextureAtlas)>,
+        Query<(Entity, &mut SpritesheetAnimation, Option<&mut TextureAtlas>)>,
     )> = SystemState::new(app.world_mut());
 
     bencher.bench_local(|| {

--- a/examples/3d.rs
+++ b/examples/3d.rs
@@ -11,7 +11,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         .add_systems(Startup, setup)
         .add_systems(Update, (update_on_keypress, orbit, draw_gizmos))

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Add the plugin to enable animations.
         // This makes the AnimationLibrary resource available to your systems.
-        .add_plugins(SpritesheetAnimationPlugin)
+        .add_plugins(SpritesheetAnimationPlugin::default())
         .add_systems(Startup, (setup, spawn_sprite.after(setup)))
         .run();
 }

--- a/examples/character.rs
+++ b/examples/character.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         .add_systems(Startup, setup)
         .add_systems(Update, control_character)

--- a/examples/composition.rs
+++ b/examples/composition.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         .add_systems(Startup, setup)
         .run();

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -29,7 +29,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         .add_systems(Startup, setup)
         .add_systems(Update, show_triggered_events)

--- a/examples/headless.rs
+++ b/examples/headless.rs
@@ -1,0 +1,57 @@
+// This example shows how to use this plugin in a bevy app without bevy_render.
+//
+// For example for a headless server with MinimalPlugins, while still using the animations events.
+
+#[path = "./common/mod.rs"]
+pub mod common;
+
+use bevy::prelude::*;
+use bevy_spritesheet_animation::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((
+            MinimalPlugins,
+            SpritesheetAnimationPlugin { enable_3d: false },
+        ))
+        .add_systems(Startup, setup)
+        .add_systems(Update, handle_animations_events)
+        .run();
+}
+
+fn setup(mut commands: Commands, mut library: ResMut<AnimationLibrary>) {
+    commands.spawn(Camera2dBundle::default());
+
+    // Create a clip that references some frames from a spritesheet
+
+    let spritesheet = Spritesheet::new(8, 8);
+
+    let clip = Clip::from_frames(spritesheet.row(3));
+
+    let clip_id = library.register_clip(clip);
+
+    // Create an animation that uses the clip
+
+    let animation = Animation::from_clip(clip_id);
+
+    let animation_id = library.register_animation(animation);
+
+    // Name the animation to retrieve it from other systems
+
+    library.name_animation(animation_id, "walk").unwrap();
+
+    // Spawn a sprite with Bevy's built-in SpriteBundle
+
+    commands.spawn((
+        // We dont even need a TextureAtlas since its only used for bevy_render (and we aren't rendering anything)
+
+        // Add a SpritesheetAnimation component that references our animation
+        SpritesheetAnimation::from_id(animation_id),
+    ));
+}
+
+fn handle_animations_events(mut events: EventReader<AnimationEvent>) {
+    for event in events.read() {
+        dbg!(event);
+    }
+}

--- a/examples/parameters.rs
+++ b/examples/parameters.rs
@@ -14,7 +14,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         .add_systems(Startup, setup)
         .run();

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         .add_systems(Startup, setup)
         .add_systems(Update, keyboard)

--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -42,7 +42,7 @@ fn main() {
     App::new()
         .add_plugins((
             DefaultPlugins.set(ImagePlugin::default_nearest()),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
             bevy::diagnostic::FrameTimeDiagnosticsPlugin,
             PerfUiPlugin,
         ))

--- a/src/animator/iterator.rs
+++ b/src/animator/iterator.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use bevy::{log::warn, reflect::prelude::*};
 
@@ -14,7 +14,7 @@ use super::cache::{AnimationCache, AnimationCacheEvent, CacheFrame};
 #[reflect(Debug)]
 pub struct IteratorFrame {
     pub atlas_index: usize,
-    pub duration: u32,
+    pub duration: Duration,
     pub clip_id: ClipId,
     pub clip_repetition: usize,
     pub animation_repetition: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!         .add_plugins(DefaultPlugins)
 //!         // Add the plugin to enable animations.
 //!         // This makes the AnimationLibrary resource available to your systems.
-//!         .add_plugins(SpritesheetAnimationPlugin)
+//!         .add_plugins(SpritesheetAnimationPlugin::default())
 //!         .add_systems(Startup, setup);
 //!
 //!     // ...

--- a/src/systems/spritesheet_animation.rs
+++ b/src/systems/spritesheet_animation.rs
@@ -18,7 +18,7 @@ pub fn play_animations(
     library: Res<AnimationLibrary>,
     mut animator: ResMut<Animator>,
     mut event_writer: EventWriter<AnimationEvent>,
-    mut query: Query<(Entity, &mut SpritesheetAnimation, &mut TextureAtlas)>,
+    mut query: Query<(Entity, &mut SpritesheetAnimation, Option<&mut TextureAtlas>)>,
 ) {
     animator.update(&time, &library, &mut event_writer, &mut query);
 }

--- a/tests/context/mod.rs
+++ b/tests/context/mod.rs
@@ -35,7 +35,7 @@ impl Context {
                     .into(),
                     ..default()
                 }),
-            SpritesheetAnimationPlugin,
+            SpritesheetAnimationPlugin::default(),
         ))
         // Insert a manual update strategy to control time
         .insert_resource(TimeUpdateStrategy::ManualInstant(Instant::now()));

--- a/tests/duration.rs
+++ b/tests/duration.rs
@@ -238,11 +238,14 @@ fn pause_resume() {
     ctx.run(50);
     ctx.check(4, []);
 
-    ctx.run(150);
+    ctx.run(50);
     ctx.check(5, []);
 
-    ctx.run(100);
+    ctx.run(150);
     ctx.check(6, []);
+
+    ctx.run(100);
+    ctx.check(7, []);
 
     // Pause
 
@@ -252,7 +255,7 @@ fn pause_resume() {
 
     for _ in 0..100 {
         ctx.run(100);
-        ctx.check(6, []); // Stays on the same frame
+        ctx.check(7, []); // Stays on the same frame
     }
 
     // Resume
@@ -261,8 +264,17 @@ fn pause_resume() {
         anim.playing = true;
     });
 
+    // wrap
+
     ctx.run(100);
-    ctx.check(7, []);
+    ctx.check(
+        4,
+        [
+            ctx.clip_rep_end(animation_id, clip_id, 0),
+            ctx.clip_end(animation_id, clip_id),
+            ctx.anim_rep_end(animation_id, 0),
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
this allow to use this plugin in a headless bevy app, for example with MinimalPlugins, and so without bevy_render.

changes:
- add a optional_3d boolean to the plugin struct
- impl Default for the plugin struct, enabling by default the 3d systems
- update all the examples to use the Default plugin impl
- add the headless example, it just print to stdout the events from the basic example
- replace most of the u32 used interally to track time by Duration. this fix hidden dangerous bugs created by either float inprecision or just wrong code because of the non-fixed unit of value. Duration ensure the duration are correctly calculated and used together. the primary bug that lead to this fix was running the app with bevy::app::ScheduleRunnerPlugin (from MinimalPlugins) which mean the app refreshed as fast as it can, instead of the screen refresh rate. this lead the Time interval to be microseconds wide instead of milliseconds. inaccurary in the durations calculations lead to the plugin not working (animations werent advancing).
- fix the pause_resume test values. now the frame update correctly without loosing durations