### PR TITLE
Tidy cache when StandardMaterial assets are removed

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -86,6 +86,7 @@ impl Plugin for SpritesheetAnimationPlugin {
                         sprite3d::setup_rendering,
                         sprite3d::sync_when_sprites_change,
                         sprite3d::sync_when_atlases_change,
+                        sprite3d::remove_dropped_standard_materials,
                     )
                         .in_set(Sprite3dSystemSet)
                         .after(AnimationSystemSet),

--- a/src/systems/sprite3d.rs
+++ b/src/systems/sprite3d.rs
@@ -383,3 +383,14 @@ fn get_or_create_mesh(
         mesh_handle
     })
 }
+
+pub(crate) fn remove_dropped_standard_materials(
+    mut cache: ResMut<Cache>,
+    mut standard_material_events: EventReader<AssetEvent<StandardMaterial>>,
+) {
+    for event in standard_material_events.read() {
+        if let AssetEvent::Removed { id } = event {
+            cache.materials.retain(|_, handle| handle.id() != *id);
+        }
+    }
+}


### PR DESCRIPTION
Refs #25 

It would be nice to have some unit test suite set up that makes it easy to test that the cache is cleared, but I don't have the time to spend doing that right now.

The style/design of the system is taken directly from how Bevy does it, see: https://github.com/bevyengine/bevy/blob/f6668cdf9f566a6fd3350dc7fcd6e2d45b35d419/crates/bevy_text/src/font_atlas_set.rs#L39

For testing, I have tested this before and after on my own game. See the linked issue for more info.

With regards to doing the same thing for `Mesh` assets, unfortunately it looks like Bevy doesn't send `Asset::REMOVED` events for the meshes we create for our `Sprite3d`s. I think this is because our `RenderAssetUsages` are set to main+render worlds. I suspect that when you send the mesh to the render world, but then despawn the entity, the render world isn't unloading, which means the asset server doesn't unload the mesh. My theory is based on me changing our `Mesh`'s `RenderAssetUsages` to just `RENDER_WORLD` and I noticed that the `EventReader<AssetEvent<Mesh>>` did end up getting events for removed meshes that did match the `cache.meshes` entries. Either way, apart from it being good house keeping, the material cleanup alone does fix my issue. It would be nice to understand the mesh cleanup side, so if you have any ideas or can confirm my theory, let me know (I can imagine we could ask on Discord how to go about this, or if there's a bug in Bevy).

Edit: I can't actually work out right now why this works. If `cache.materials` is holding on to the `Handle<StandardMaterial>`, then why does the `StandardMaterial` get dropped? Maybe this is related to strong and weak handles. I'm glad it works as is, so don't let this comment block the PR, but I might check tomorrow if I can answer this for my own knowledge.

Edit 2: Oh, the mesh handle is a strong one: `cache.meshes.insert(mesh_id, mesh_handle.clone());` but the material handle is a weak one: `cache.materials.insert(material_id, material_handle.clone_weak());`. @merwaaan do you recall if there was a reason you varied the strong/weak here?