### PR TITLE
Add missing support for ImageNode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,11 @@ exclude = ["assets/example.gif", "assets/example3d.gif"]
 bevy = { version = "0.15.0", default-features = false, features = [
   "bevy_pbr",
   "bevy_sprite",
+  "bevy_ui",
 ] }
 # Temporary dep until the bevy_image export is fixed
 # https://github.com/bevyengine/bevy/issues/16563
-bevy_internal = { version = "0.15", features = [ "bevy_image" ]}
+bevy_internal = { version = "0.15", features = ["bevy_image"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bevy_spritesheet_animation is a [Bevy](https://bevyengine.org/) plugin for easil
 
 # Features
 
-- Animate 2D and [3D sprites](#3d-sprites)! 🎉
+- Animate 2D sprites, [3D sprites](#3d-sprites) and UI images! 🎉
 - A single Bevy [component](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/components/spritesheet_animation/struct.SpritesheetAnimation.html) to add to your entities to play animations.
 - Tunable parameters: [duration](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/enum.AnimationDuration.html), [repetitions](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/enum.AnimationRepeat.html), [direction](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/enum.AnimationDirection.html), [easing](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/easing/enum.Easing.html).
 - [Composable animations](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/struct.Animation.html) from multiple clips.

--- a/src/animator.rs
+++ b/src/animator.rs
@@ -21,6 +21,7 @@ use bevy::{
     reflect::prelude::*,
     sprite::Sprite,
     time::Time,
+    ui::widget::ImageNode,
 };
 use iterator::AnimationIteratorEvent;
 use std::{collections::HashMap, time::Duration};
@@ -60,6 +61,7 @@ impl Animator {
             &mut SpritesheetAnimation,
             Option<&mut Sprite>,
             Option<&mut Sprite3d>,
+            Option<&mut ImageNode>,
         )>,
     ) {
         // Clear outdated animation instances associated to entities that do not have the component anymore
@@ -69,8 +71,13 @@ impl Animator {
 
         // Run animations for all the entities
 
-        for (entity, mut entity_animation, mut maybe_entity_sprite, mut maybe_entity_3dsprite) in
-            query.iter_mut()
+        for (
+            entity,
+            mut entity_animation,
+            mut maybe_entity_sprite,
+            mut maybe_entity_3dsprite,
+            mut maybe_entity_image_node,
+        ) in query.iter_mut()
         {
             // Create a new animation instance if:
             let needs_new_animation_instance = match self.animation_instances.get(&entity) {
@@ -104,6 +111,7 @@ impl Animator {
                     &entity,
                     maybe_entity_sprite.as_deref_mut(),
                     maybe_entity_3dsprite.as_deref_mut(),
+                    maybe_entity_image_node.as_deref_mut(),
                     event_writer,
                 );
 
@@ -135,6 +143,7 @@ impl Animator {
                         &entity,
                         maybe_entity_sprite.as_deref_mut(),
                         maybe_entity_3dsprite.as_deref_mut(),
+                        maybe_entity_image_node.as_deref_mut(),
                         event_writer,
                     )
                     .inspect(|new_frame| {
@@ -181,6 +190,7 @@ impl Animator {
                     &entity,
                     maybe_entity_sprite.as_deref_mut(),
                     maybe_entity_3dsprite.as_deref_mut(),
+                    maybe_entity_image_node.as_deref_mut(),
                     event_writer,
                 )
                 .or_else(|| {
@@ -224,6 +234,7 @@ impl Animator {
         entity: &Entity,
         maybe_sprite: Option<&mut Sprite>,
         maybe_3dsprite: Option<&mut Sprite3d>,
+        maybe_image_node: Option<&mut ImageNode>,
         event_writer: &mut EventWriter<AnimationEvent>,
     ) -> Option<(IteratorFrame, AnimationProgress)> {
         let maybe_frame = iterator.next();
@@ -239,6 +250,12 @@ impl Animator {
             }
 
             if let Some(atlas) = maybe_3dsprite.and_then(|sprite| sprite.texture_atlas.as_mut()) {
+                if atlas.index != frame.atlas_index {
+                    atlas.index = frame.atlas_index;
+                }
+            }
+
+            if let Some(atlas) = maybe_image_node.and_then(|image| image.texture_atlas.as_mut()) {
                 if atlas.index != frame.atlas_index {
                     atlas.index = frame.atlas_index;
                 }

--- a/src/systems/spritesheet_animation.rs
+++ b/src/systems/spritesheet_animation.rs
@@ -6,6 +6,7 @@ use bevy::{
     },
     sprite::Sprite,
     time::Time,
+    ui::widget::ImageNode,
 };
 
 use crate::{
@@ -25,6 +26,7 @@ pub fn play_animations(
         &mut SpritesheetAnimation,
         Option<&mut Sprite>,
         Option<&mut Sprite3d>,
+        Option<&mut ImageNode>,
     )>,
 ) {
     animator.update(&time, &library, &mut event_writer, &mut query);


### PR DESCRIPTION
A future change may consider redesigning this to use generics. This would allow users of the crate to provide their own implementation. 

That's out of scope for now, and easiest to just add support for the missing 3rd kind of image we need: `ImageNode`.