### PR TITLE
Encapsulate Animator.update query data in SpritesheetAnimationQuery

### DIFF
--- a/src/systems/spritesheet_animation.rs
+++ b/src/systems/spritesheet_animation.rs
@@ -1,17 +1,13 @@
 use bevy::{
     ecs::{
-        entity::Entity,
         event::EventWriter,
         system::{Query, Res, ResMut},
     },
-    sprite::Sprite,
     time::Time,
-    ui::widget::ImageNode,
 };
 
 use crate::{
-    animator::Animator,
-    components::{sprite3d::Sprite3d, spritesheet_animation::SpritesheetAnimation},
+    animator::{Animator, SpritesheetAnimationQuery},
     events::AnimationEvent,
     library::AnimationLibrary,
 };
@@ -21,13 +17,7 @@ pub fn play_animations(
     library: Res<AnimationLibrary>,
     mut animator: ResMut<Animator>,
     mut event_writer: EventWriter<AnimationEvent>,
-    mut query: Query<(
-        Entity,
-        &mut SpritesheetAnimation,
-        Option<&mut Sprite>,
-        Option<&mut Sprite3d>,
-        Option<&mut ImageNode>,
-    )>,
+    mut query: Query<SpritesheetAnimationQuery>,
 ) {
     animator.update(&time, &library, &mut event_writer, &mut query);
 }


### PR DESCRIPTION
## Objective 

- Allow adding support for Bevy's `custom_cursor` `CursorIcon`s for Bevy 0.16: https://github.com/bevyengine/bevy/pull/17121.
- To feature flag that, we need the query data to be a struct, because you cannot add a feature gate on inline query fields.
- The change makes the code simpler anyway, since we can now pass around the query data item.

## Test plan

- Ran two examples and proved they still work: `basic` and `3d`.
- The change may look scary, but really it just adds `item.` prefix to the previously extracted variables and then `rustfmt` does its thing.

## Future work

- Once this is merged, I'll submit a new PR and the query data will look like this:

```rust
#[derive(QueryData)]
#[query_data(mutable, derive(Debug))]
pub struct SpritesheetAnimationQuery {
    entity: Entity,
    spritesheet_animation: &'static mut SpritesheetAnimation,
    sprite: Option<&'static mut Sprite>,
    sprite3d: Option<&'static mut Sprite3d>,
    image_node: Option<&'static mut ImageNode>,
    #[cfg(feature = "custom_cursor")]
    cursor_icon: Option<&'static mut CursorIcon>,
}
```