### PR TITLE
3d light interaction with normals

### DIFF
--- a/src/components/sprite3d.rs
+++ b/src/components/sprite3d.rs
@@ -58,7 +58,7 @@ pub struct Sprite3d {
     pub alpha_mode: AlphaMode,
 
     /// Whether the sprite should be rendered as unlit.
-    /// `false` (default) allows for lighting.
+    /// `true` (default) disables lighting.
     pub unlit: bool,
 
     /// An emissive colour, if the sprite should emit light.

--- a/src/components/sprite3d.rs
+++ b/src/components/sprite3d.rs
@@ -20,7 +20,7 @@ use bevy::{
 /// The library requires the sprite's texture to be loaded before setting everything up.
 /// If the texture has already been loaded (for example, in a loading stage), the sprite will appear on the next update.
 /// Otherwise, the actual rendering will be delayed and the sprite will not be visible during a few frames.
-#[derive(Component, Default, Debug, Reflect)]
+#[derive(Component, Debug, Reflect)]
 #[require(Transform, Visibility)]
 #[reflect(Component, Debug)]
 pub struct Sprite3d {
@@ -49,16 +49,44 @@ pub struct Sprite3d {
     /// The position of the sprite's origin
     pub anchor: Anchor,
 
-    /// If the sprite should interact with light.
+    /// The sprite's alpha mode.
+    ///
+    /// - `Mask(0.5)` (default) only allows fully opaque or fully transparent pixels
+    ///   (cutoff at `0.5`).
+    /// - `Blend` allows partially transparent pixels (slightly more expensive).
+    /// - Use any other value to achieve desired blending effect.
+    pub alpha_mode: AlphaMode,
+
+    /// Whether the sprite should be rendered as unlit.
+    /// `false` (default) allows for lighting.
     pub unlit: bool,
+
+    /// An emissive colour, if the sprite should emit light.
+    /// `LinearRgba::Black` (default) does nothing.
+    pub emissive: LinearRgba,
+}
+
+impl Default for Sprite3d {
+    fn default() -> Self {
+        Self {
+            image: Default::default(),
+            texture_atlas: Default::default(),
+            color: Default::default(),
+            flip_x: Default::default(),
+            flip_y: Default::default(),
+            custom_size: Default::default(),
+            anchor: Default::default(),
+            alpha_mode: AlphaMode::Mask(0.5),
+            unlit: true,
+            emissive: LinearRgba::BLACK,
+        }
+    }
 }
 
 impl Sprite3d {
     pub fn from_image(image: Handle<Image>) -> Self {
         Self {
             image,
-            // unlit sprites is default behaviour
-            unlit: true,
             ..Default::default()
         }
     }
@@ -66,11 +94,24 @@ impl Sprite3d {
     pub fn from_atlas_image(image: Handle<Image>, atlas: TextureAtlas) -> Self {
         Self {
             image,
-            // unlit sprites is default behaviour
-            unlit: true,
             texture_atlas: Some(atlas),
             ..Default::default()
         }
+    }
+
+    pub fn with_alpha_mode(mut self, alpha_mode: AlphaMode) -> Self {
+        self.alpha_mode = alpha_mode;
+        self
+    }
+
+    pub fn with_unlit(mut self, unlit: bool) -> Self {
+        self.unlit = unlit;
+        self
+    }
+
+    pub fn with_emissive(mut self, emissive: LinearRgba) -> Self {
+        self.emissive = emissive;
+        self
     }
 
     pub fn with_color(mut self, color: impl Into<Color>) -> Self {
@@ -91,11 +132,6 @@ impl Sprite3d {
 
     pub fn with_anchor(mut self, anchor: impl Into<Anchor>) -> Self {
         self.anchor = anchor.into();
-        self
-    }
-
-    pub fn with_unlit(mut self, unlit: bool) -> Self {
-        self.unlit = unlit;
         self
     }
 }

--- a/src/systems/sprite3d.rs
+++ b/src/systems/sprite3d.rs
@@ -168,6 +168,9 @@ pub fn setup_rendering(
                 unlit: sprite.unlit,
                 alpha_mode: sprite.alpha_mode,
                 emissive: sprite.emissive,
+                // TODO
+                // these are sensible values for 3d rendering,
+                // but could be extended to public API
                 perceptual_roughness: 0.5,
                 reflectance: 0.15,
                 ..default()
@@ -271,6 +274,9 @@ fn get_or_create_material(
                 unlit: sprite.unlit,
                 alpha_mode: sprite.alpha_mode,
                 emissive: sprite.emissive,
+                // TODO
+                // these are sensible values for 3d rendering,
+                // but could be extended to public API
                 perceptual_roughness: 0.5,
                 reflectance: 0.15,
                 ..default()

--- a/src/systems/sprite3d.rs
+++ b/src/systems/sprite3d.rs
@@ -13,11 +13,12 @@ use bevy::{
         alpha::AlphaMode,
         mesh::{Mesh, PrimitiveTopology},
         render_asset::RenderAssetUsages,
+        render_resource::Face,
     },
     sprite::TextureAtlasLayout,
 };
 
-use crate::components::sprite3d::Sprite3d;
+use crate::prelude::Sprite3d;
 
 /// Cached data for the 3D sprites
 #[derive(Resource, Debug, Default, Reflect)]
@@ -40,7 +41,49 @@ pub struct Cache {
 struct MaterialId {
     image: Handle<Image>,
     color: u32,
+    alpha_mode: HashableAlphaMode,
     unlit: bool,
+    emissive: HashableLinearRgba,
+}
+
+#[derive(Eq, PartialEq, Debug, Reflect)]
+struct HashableAlphaMode(AlphaMode);
+
+impl Hash for HashableAlphaMode {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self.0 {
+            AlphaMode::Opaque => 0.hash(state),
+            AlphaMode::Mask(f) => {
+                1.hash(state);
+                f.to_bits().hash(state);
+            }
+            AlphaMode::Blend => 2.hash(state),
+            AlphaMode::Premultiplied => 3.hash(state),
+            AlphaMode::Add => 4.hash(state),
+            AlphaMode::Multiply => 5.hash(state),
+            AlphaMode::AlphaToCoverage => 6.hash(state),
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Debug, Reflect)]
+struct HashableLinearRgba([u8; 4]);
+
+impl HashableLinearRgba {
+    fn new(c: LinearRgba) -> Self {
+        Self([
+            (c.red * 255.) as u8,
+            (c.green * 255.) as u8,
+            (c.blue * 255.) as u8,
+            (c.alpha * 255.) as u8,
+        ])
+    }
+}
+
+impl Hash for HashableLinearRgba {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
+    }
 }
 
 impl MaterialId {
@@ -48,7 +91,9 @@ impl MaterialId {
         Self {
             image: image_handle.clone_weak(),
             color: sprite.color.to_linear().as_u32(),
+            alpha_mode: HashableAlphaMode(sprite.alpha_mode),
             unlit: sprite.unlit,
+            emissive: HashableLinearRgba::new(sprite.emissive),
         }
     }
 }
@@ -116,15 +161,17 @@ pub fn setup_rendering(
         // Add a material to the entity if it does not have one yet
 
         if maybe_material.is_none() {
-            let material = StandardMaterial {
+            let material_handle = materials.add(StandardMaterial {
                 base_color_texture: Some(sprite.image.clone()),
                 base_color: sprite.color,
+                cull_mode: Some(Face::Back),
                 unlit: sprite.unlit,
-                alpha_mode: AlphaMode::Blend,
+                alpha_mode: sprite.alpha_mode,
+                emissive: sprite.emissive,
+                perceptual_roughness: 0.5,
+                reflectance: 0.15,
                 ..default()
-            };
-
-            let material_handle = materials.add(material);
+            });
 
             commands
                 .entity(entity)
@@ -220,8 +267,12 @@ fn get_or_create_material(
             let material_handle: Handle<StandardMaterial> = materials.add(StandardMaterial {
                 base_color_texture: Some(sprite.image.clone()),
                 base_color: sprite.color,
+                cull_mode: Some(Face::Back),
                 unlit: sprite.unlit,
-                alpha_mode: AlphaMode::Blend,
+                alpha_mode: sprite.alpha_mode,
+                emissive: sprite.emissive,
+                perceptual_roughness: 0.5,
+                reflectance: 0.15,
                 ..default()
             });
 
@@ -314,6 +365,18 @@ fn try_get_or_create_mesh(
                             half.y - offset.y,
                             0.0,
                         ],
+                    ],
+                );
+
+                mesh.insert_attribute(
+                    Mesh::ATTRIBUTE_NORMAL,
+                    vec![
+                        [0.0, 0.0, 1.0],
+                        [0.0, 0.0, 1.0],
+                        [0.0, 0.0, 1.0],
+                        [0.0, 0.0, 1.0],
+                        [0.0, 0.0, 1.0],
+                        [0.0, 0.0, 1.0],
                     ],
                 );
 


### PR DESCRIPTION
Added normals and more ```MaterialId``` attributes; though could be useful to have a custom ```Sprite3dMaterial``` type to get more control over several Material/Rendering properties. Also added correct Default impl of ```unlit```, should close #29 