### PR TITLE
Add support for CursorIcon::Custom behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ edition = "2021"
 resolver = "2"
 exclude = ["assets/example.gif", "assets/example3d.gif"]
 
+[features]
+default = []
+custom_cursor = ["bevy/bevy_winit", "bevy/custom_cursor"]
+
 [dependencies]
 bevy = { version = "0.15.0", default-features = false, features = [
   "bevy_pbr",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bevy_spritesheet_animation is a [Bevy](https://bevyengine.org/) plugin for easil
 
 # Features
 
-- Animate 2D sprites, [3D sprites](#3d-sprites) and UI images! 🎉
+- Animate 2D sprites, [3D sprites](#3d-sprites), UI images and custom cursor icons! 🎉
 - A single Bevy [component](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/components/spritesheet_animation/struct.SpritesheetAnimation.html) to add to your entities to play animations.
 - Tunable parameters: [duration](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/enum.AnimationDuration.html), [repetitions](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/enum.AnimationRepeat.html), [direction](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/enum.AnimationDirection.html), [easing](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/easing/enum.Easing.html).
 - [Composable animations](https://docs.rs/bevy_spritesheet_animation/latest/bevy_spritesheet_animation/animation/struct.Animation.html) from multiple clips.
@@ -256,7 +256,37 @@ fn spawn_character(mut commands: Commands, mut library: ResMut<AnimationLibrary>
             .with_atlas(atlas_layout)
             .with_anchor(Anchor::BottomRight)
             .build(),
-        SpritesheetAnimation::from_id(animation_id)
+        SpritesheetAnimation::from_id(animation_id),
+    ));
+}
+```
+
+## Custom cursor icons
+
+You can animate custom cursor icons using this crate.
+
+You need to enable the optional `custom_cursor` feature.
+
+```toml
+[dependencies]
+bevy = { version = "...", features = ["...", "custom_cursor"] }
+bevy_spritesheet_animation = { version = "...", features = ["custom_cursor"] }
+```
+
+When you spawn your cursor icon entity, add a `SpritesheetAnimation` component as usual to play an animation.
+
+```rust
+fn spawn_cursor_icon(mut commands: Commands, mut library: ResMut<AnimationLibrary>) {
+    // ...
+
+    let animation_id = library.register_animation(animation);
+
+    commands.spawn((
+        CursorIcon::Custom(CustomCursor::Image(CustomCursorImage {
+            // ...
+        })),
+
+        SpritesheetAnimation::from_id(animation_id),
     ));
 }
 ```

--- a/src/animator.rs
+++ b/src/animator.rs
@@ -11,6 +11,8 @@ use crate::{
     events::AnimationEvent,
     library::AnimationLibrary,
 };
+#[cfg(feature = "custom_cursor")]
+use bevy::winit::cursor::{CursorIcon, CustomCursor};
 use bevy::{
     ecs::{
         entity::Entity,
@@ -59,6 +61,8 @@ pub struct SpritesheetAnimationQuery {
     sprite: Option<&'static mut Sprite>,
     sprite3d: Option<&'static mut Sprite3d>,
     image_node: Option<&'static mut ImageNode>,
+    #[cfg(feature = "custom_cursor")]
+    cursor_icon: Option<&'static mut CursorIcon>,
 }
 
 impl Animator {
@@ -243,6 +247,28 @@ impl Animator {
                 .image_node
                 .as_deref_mut()
                 .and_then(|image| image.texture_atlas.as_mut())
+            {
+                if atlas.index != frame.atlas_index {
+                    atlas.index = frame.atlas_index;
+                }
+            }
+
+            #[cfg(feature = "custom_cursor")]
+            if let Some(atlas) = item
+                .cursor_icon
+                .as_deref_mut()
+                .and_then(|cursor_icon| {
+                    if let CursorIcon::Custom(CustomCursor::Image {
+                        ref mut texture_atlas,
+                        ..
+                    }) = *cursor_icon
+                    {
+                        Some(texture_atlas)
+                    } else {
+                        None
+                    }
+                })
+                .and_then(|atlas| atlas.as_mut())
             {
                 if atlas.index != frame.atlas_index {
                     atlas.index = frame.atlas_index;


### PR DESCRIPTION
This depends on Bevy 0.16 (not yet released), so this isn't ready to merge, but just pushing up a PR in advance.