### PR TITLE
Add deregister_clip and deregister_animation

### DIFF
--- a/tests/names.rs
+++ b/tests/names.rs
@@ -69,6 +69,14 @@ fn clips() {
     assert_eq!(ctx.library().get_clip_name(clip1_id), Some("first"));
 
     assert_eq!(ctx.library().clip_names().len(), 1);
+
+    // Deregister it, and check that the name is removed
+    ctx.library().deregister_clip(clip1_id);
+
+    assert!(!ctx.library().is_clip_name(clip1_id, "first"));
+    assert_eq!(ctx.library().get_clip_name(clip1_id), None);
+    assert_eq!(ctx.library().clip_with_name("first"), None);
+    assert_eq!(ctx.library().clip_names().len(), 0);
 }
 
 #[test]
@@ -166,6 +174,14 @@ fn animations() {
     );
 
     assert_eq!(ctx.library().animation_names().len(), 1);
+
+    // Deregister it, and check that the name is removed
+    ctx.library().deregister_animation(animation1_id);
+
+    assert!(!ctx.library().is_animation_name(animation1_id, "first"));
+    assert_eq!(ctx.library().get_animation_name(animation1_id), None);
+    assert_eq!(ctx.library().animation_with_name("first"), None);
+    assert_eq!(ctx.library().animation_names().len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #36.

This allows one to setup animations in one system, and tear them down later.

While this fixes #36, I think there could be an opportunity to explore a different kind of `AnimationLibrary` design with "animation library as entities". Some shower thoughts on it:

1. It would allow you to use `StateScoped` out of the box, and avoid the need to manage the lifecycle of an animation yourself, i.e., it would probably obsolete this kind of PR.
2. You could add an `AnimationName` (or `ClipName`) component to an animation or clip to name, which is a very natural way of doing things with ECS/Bevy.
3. We'd possibly get some observer support out of the box rather than having to rely on reading events, but I haven't really thought it through yet.

Regarding the choice to use `deregister` vs `unregister`, refer to: https://english.stackexchange.com/questions/25931/unregister-vs-deregister.

I used these two answers. Essentially the `de` is the act of undoing what was originally done which was `register`, hence `deregister`:

1. https://english.stackexchange.com/a/40095
4. https://english.stackexchange.com/a/154691