### PR TITLE
Fix buggy ID generation when deregistering

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -1,6 +1,10 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::Arc,
+    sync::{
+        // TODO: Use bevy_platform when updated to Bevy 0.16.
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
 
 use bevy::{ecs::reflect::*, prelude::Resource, reflect::prelude::*};
@@ -75,6 +79,8 @@ pub struct AnimationLibrary {
     /// Animation caches, one for each animation.
     /// They contain all the data required to play an animation.
     animation_caches: HashMap<AnimationId, Arc<AnimationCache>>,
+
+    next_id: AtomicUsize,
 }
 
 impl AnimationLibrary {
@@ -97,7 +103,7 @@ impl AnimationLibrary {
     /// ```
     pub fn register_clip(&mut self, clip: Clip) -> ClipId {
         let id = ClipId {
-            value: self.clips.len(),
+            value: self.next_id.fetch_add(1, Ordering::Relaxed),
         };
 
         self.clips.insert(id, clip);
@@ -265,7 +271,7 @@ impl AnimationLibrary {
     /// ```
     pub fn register_animation(&mut self, animation: Animation) -> AnimationId {
         let id = AnimationId {
-            value: self.animations.len(),
+            value: self.next_id.fetch_add(1, Ordering::Relaxed),
         };
 
         self.animations.insert(id, animation);
@@ -450,7 +456,7 @@ impl AnimationLibrary {
     /// ```
     pub fn new_marker(&mut self) -> AnimationMarkerId {
         let id = AnimationMarkerId {
-            value: self.markers.len(),
+            value: self.next_id.fetch_add(1, Ordering::Relaxed),
         };
 
         self.markers.insert(id);

--- a/src/library.rs
+++ b/src/library.rs
@@ -561,3 +561,54 @@ impl AnimationLibrary {
         self.animation_caches.get(&animation_id).unwrap().clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn animation_ids_should_be_unique_after_deregistration() {
+        let mut library = AnimationLibrary::default();
+
+        // First animation registration.
+        let clip1 = Clip::from_frames(vec![0]);
+        let clip_id1 = library.register_clip(clip1);
+        let anim1 = Animation::from_clip(clip_id1);
+        let anim_id1 = library.register_animation(anim1);
+
+        // Deregister the animation and its clips.
+        library.deregister_animation(anim_id1);
+
+        // Second animation registration should get a unique ID.
+        let clip2 = Clip::from_frames(vec![1]);
+        let clip_id2 = library.register_clip(clip2);
+        let anim2 = Animation::from_clip(clip_id2);
+        let anim_id2 = library.register_animation(anim2);
+
+        assert_ne!(
+            anim_id1, anim_id2,
+            "Each animation should receive a unique ID even after deregistration"
+        );
+    }
+
+    #[test]
+    fn clip_ids_should_be_unique_after_deregistration() {
+        let mut library = AnimationLibrary::default();
+
+        // First clip registration.
+        let clip1 = Clip::from_frames(vec![0]);
+        let clip_id1 = library.register_clip(clip1);
+
+        // Deregister the clip.
+        library.deregister_clip(clip_id1);
+
+        // Second clip registration should get a unique ID.
+        let clip2 = Clip::from_frames(vec![1]);
+        let clip_id2 = library.register_clip(clip2);
+
+        assert_ne!(
+            clip_id1, clip_id2,
+            "Each clip should receive a unique ID even after deregistration"
+        );
+    }
+}


### PR DESCRIPTION
Generated IDs are buggy when deregistration is used.

The problem is that `HashMap`'s `len()` doesn't represent gaps in IDs. When you remove items:

1. First registration: len = 0, ID = 0
2. Second registration: len = 1, ID = 1
3. Third registration: len = 2, ID = 2
4. Deregister ID 1: len = 2 (not 1!)
5. Next registration: len = 2, ID = 2 (duplicate!)

Looks like CI isn't running the test, but here's the failure before the fix.

```
running 2 tests
test library::tests::animation_ids_should_be_unique_after_deregistration ... FAILED
test library::tests::clip_ids_should_be_unique_after_deregistration ... FAILED

successes:

successes:

failures:

---- library::tests::animation_ids_should_be_unique_after_deregistration stdout ----

thread 'library::tests::animation_ids_should_be_unique_after_deregistration' panicked at src/library.rs:588:9:
assertion `left != right` failed: Each animation should receive a unique ID even after deregistration
  left: AnimationId { value: 0 }
 right: AnimationId { value: 0 }
stack backtrace:
   0:        0x102849b18 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h44fbca845d867dea
   1:        0x1028630b0 - core::fmt::write::h6d08e7db95391aae
   2:        0x10284778c - std::io::Write::write_fmt::h9098c068b35afafd
   3:        0x1028499cc - std::sys::backtrace::BacktraceLock::print::h97a801e0a846a1dc
   4:        0x10284af54 - std::panicking::default_hook::{{closure}}::hff9bdfb2744e3c1a
   5:        0x10284ad68 - std::panicking::default_hook::h1c466b219e82f0d5
   6:        0x10281aac8 - test::test_main::{{closure}}::hbb0cd8e5ef347e87
   7:        0x10284ba70 - std::panicking::rust_panic_with_hook::h888d4874efbbfe1e
   8:        0x10284b660 - std::panicking::begin_panic_handler::{{closure}}::hf4ac441d08323fe9
   9:        0x102849fdc - std::sys::backtrace::__rust_end_short_backtrace::h48e3eb6b9e627583
  10:        0x10284b308 - __rustc[33a63cc8ebf7130a]::rust_begin_unwind
  11:        0x10286cbac - core::panicking::panic_fmt::hc8a5295621ff0f3b
  12:        0x10286ce40 - core::panicking::assert_failed_inner::h1b4fd5bf8c317cb0
  13:        0x1028688b8 - core::panicking::assert_failed::h3c53cd3e9e26b820
  14:        0x1027e8a08 - bevy_spritesheet_animation::library::tests::animation_ids_should_be_unique_after_deregistration::hd4a14b6d0be70e4c
  15:        0x1027e998c - core::ops::function::FnOnce::call_once::hb9f3f5103684e32d
  16:        0x10281ef5c - test::__rust_begin_short_backtrace::hb5c49288a06289b8
  17:        0x10281e1b4 - test::run_test::{{closure}}::h205bb9b415022a3a
  18:        0x1027edd74 - std::sys::backtrace::__rust_begin_short_backtrace::h93af8a923bbe3002
  19:        0x1027f0f48 - core::ops::function::FnOnce::call_once{{vtable.shim}}::ha27a1db13812ff27
  20:        0x10284d4d4 - std::sys::pal::unix::thread::Thread::new::thread_start::h45aa0b9501b99426
  21:        0x194b39c0c - __pthread_cond_wait

---- library::tests::clip_ids_should_be_unique_after_deregistration stdout ----

thread 'library::tests::clip_ids_should_be_unique_after_deregistration' panicked at src/library.rs:609:9:
assertion `left != right` failed: Each clip should receive a unique ID even after deregistration
  left: ClipId { value: 0 }
 right: ClipId { value: 0 }
stack backtrace:
   0:        0x102849b18 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h44fbca845d867dea
   1:        0x1028630b0 - core::fmt::write::h6d08e7db95391aae
   2:        0x10284778c - std::io::Write::write_fmt::h9098c068b35afafd
   3:        0x1028499cc - std::sys::backtrace::BacktraceLock::print::h97a801e0a846a1dc
   4:        0x10284af54 - std::panicking::default_hook::{{closure}}::hff9bdfb2744e3c1a
   5:        0x10284ad68 - std::panicking::default_hook::h1c466b219e82f0d5
   6:        0x10281aac8 - test::test_main::{{closure}}::hbb0cd8e5ef347e87
   7:        0x10284ba70 - std::panicking::rust_panic_with_hook::h888d4874efbbfe1e
   8:        0x10284b660 - std::panicking::begin_panic_handler::{{closure}}::hf4ac441d08323fe9
   9:        0x102849fdc - std::sys::backtrace::__rust_end_short_backtrace::h48e3eb6b9e627583
  10:        0x10284b308 - __rustc[33a63cc8ebf7130a]::rust_begin_unwind
  11:        0x10286cbac - core::panicking::panic_fmt::hc8a5295621ff0f3b
  12:        0x10286ce40 - core::panicking::assert_failed_inner::h1b4fd5bf8c317cb0
  13:        0x1028688dc - core::panicking::assert_failed::hebd3a56c870e4894
  14:        0x1027e8d40 - bevy_spritesheet_animation::library::tests::clip_ids_should_be_unique_after_deregistration::he544ed60cf84bac4
  15:        0x1027e9964 - core::ops::function::FnOnce::call_once::h9a3d20bf7b7f2626
  16:        0x10281ef5c - test::__rust_begin_short_backtrace::hb5c49288a06289b8
  17:        0x10281e1b4 - test::run_test::{{closure}}::h205bb9b415022a3a
  18:        0x1027edd74 - std::sys::backtrace::__rust_begin_short_backtrace::h93af8a923bbe3002
  19:        0x1027f0f48 - core::ops::function::FnOnce::call_once{{vtable.shim}}::ha27a1db13812ff27
  20:        0x10284d4d4 - std::sys::pal::unix::thread::Thread::new::thread_start::h45aa0b9501b99426
  21:        0x194b39c0c - __pthread_cond_wait


failures:
    library::tests::animation_ids_should_be_unique_after_deregistration
    library::tests::clip_ids_should_be_unique_after_deregistration

test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

After the fix the test passes:

```
running 2 tests
test library::tests::animation_ids_should_be_unique_after_deregistration ... ok
test library::tests::clip_ids_should_be_unique_after_deregistration ... ok

successes:

successes:
    library::tests::animation_ids_should_be_unique_after_deregistration
    library::tests::clip_ids_should_be_unique_after_deregistration

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```