### PR TITLE
Added grouping key to prevent stalled animations while rapidly changing rows within an animation

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -118,6 +118,9 @@ pub struct Animation {
     direction: Option<AnimationDirection>,
     /// The optional easing of this animation
     easing: Option<Easing>,
+    /// An optional key to group animations that are variants (e.g., different directions)
+    /// of the same conceptual animation.
+    pub animation_group_key: Option<String>,
 }
 
 impl Animation {
@@ -129,6 +132,7 @@ impl Animation {
             repetitions: None,
             direction: None,
             easing: None,
+            animation_group_key: None,
         }
     }
 
@@ -140,6 +144,7 @@ impl Animation {
             repetitions: None,
             direction: None,
             easing: None,
+            animation_group_key: None,
         }
     }
 
@@ -208,6 +213,16 @@ impl Animation {
 
     pub fn set_easing(&mut self, easing: Easing) -> &mut Self {
         self.easing = Some(easing);
+        self
+    }
+
+    pub fn with_group_key(mut self, key: impl Into<String>) -> Self {
+        self.animation_group_key = Some(key.into());
+        self
+    }
+
+    pub fn set_group_key(&mut self, key: impl Into<String>) -> &mut Self {
+        self.animation_group_key = Some(key.into());
         self
     }
 }

--- a/src/animator.rs
+++ b/src/animator.rs
@@ -19,6 +19,7 @@ use bevy::{
         reflect::*,
         system::{Query, Resource},
     },
+    log::warn,
     reflect::prelude::*,
     sprite::Sprite,
     time::Time,
@@ -78,10 +79,31 @@ impl Animator {
         // Run animations for all the entities
 
         for mut item in query.iter_mut() {
+            let current_component_animation_id = item.spritesheet_animation.animation_id;
+            let mut previous_accumulated_time = Duration::ZERO;
+            let mut is_directional_change_of_same_type = false;
+
+            // Check if this is a change of AnimationId for an existing instance
+            if let Some(existing_instance) = self.animation_instances.get(&item.entity) {
+                if existing_instance.animation_id != current_component_animation_id {
+                    // AnimationId has changed. Let's see if it's a grouped change.
+                    let old_animation_data = library.get_animation(existing_instance.animation_id);
+                    let new_animation_data = library.get_animation(current_component_animation_id);
+
+                    if old_animation_data.animation_group_key.is_some() && // Both must have a key
+                       old_animation_data.animation_group_key == new_animation_data.animation_group_key
+                    {
+                        // It's a change within the same animation group (e.g., different direction)
+                        is_directional_change_of_same_type = true;
+                        previous_accumulated_time = existing_instance.accumulated_time;
+                    }
+                }
+            }
+
             // Create a new animation instance if:
             let needs_new_animation_instance = match self.animation_instances.get(&item.entity) {
                 // The entity has an animation instance already but it switched animation
-                Some(instance) => instance.animation_id != item.spritesheet_animation.animation_id,
+                Some(instance) => instance.animation_id != current_component_animation_id,
                 // The entity has no animation instance yet
                 None => true,
             };
@@ -89,7 +111,7 @@ impl Animator {
             if needs_new_animation_instance {
                 // Create a new iterator for this animation
 
-                let cache = library.get_animation_cache(item.spritesheet_animation.animation_id);
+                let cache = library.get_animation_cache(current_component_animation_id);
 
                 let mut iterator = AnimationIterator::new(cache.clone());
 
@@ -104,15 +126,32 @@ impl Animator {
 
                 // Create the instance and immediately play the first frame
 
-                let first_frame = Self::play_frame(&mut iterator, &mut item, event_writer);
+                let first_frame_data = Self::play_frame(&mut iterator, &mut item, event_writer);
+
+                let accumulated_time_for_new_instance = if is_directional_change_of_same_type {
+                    // If it's a grouped directional change, carry over the accumulated time.
+                    // Ensure the carried-over time isn't nonsensically larger than the new frame's duration,
+                    // though the while loop below should handle advancing immediately if it is.
+                    if let Some((ref frame, _)) = first_frame_data {
+                        if previous_accumulated_time > frame.duration && !frame.duration.is_zero() {
+                            // If previous time already exceeds new frame's duration,
+                            // it means we should have ticked. Let the while loop handle it.
+                            // Or, cap it: previous_accumulated_time.min(frame.duration)
+                            // For simplicity, let's just carry it over. The while loop will tick.
+                        }
+                    }
+                    previous_accumulated_time
+                } else {
+                    Duration::ZERO
+                };
 
                 self.animation_instances.insert(
                     item.entity,
                     AnimationInstance {
-                        animation_id: item.spritesheet_animation.animation_id,
+                        animation_id: current_component_animation_id,
                         iterator,
-                        current_frame: first_frame,
-                        accumulated_time: Duration::ZERO,
+                        current_frame: first_frame_data,
+                        accumulated_time: accumulated_time_for_new_instance,
                     },
                 );
             }
@@ -121,28 +160,24 @@ impl Animator {
 
             // Apply manual progress updates
 
-            if animation_instance
-                .current_frame
-                .as_ref()
-                .filter(|frame| item.spritesheet_animation.progress != frame.1)
-                .is_some()
+            if let Some((ref _current_iterator_frame, current_iterator_actual_progress)) =
+                animation_instance.current_frame
             {
-                if animation_instance
-                    .iterator
-                    .to(item.spritesheet_animation.progress)
-                {
-                    Self::play_frame(&mut animation_instance.iterator, &mut item, event_writer)
-                        .inspect(|new_frame| {
-                            animation_instance.current_frame = Some(new_frame.clone());
-                            animation_instance.accumulated_time = Duration::ZERO;
-                        });
-                } else {
-                    // Restore to the last valid progress if invalid
-                    item.spritesheet_animation.progress = animation_instance
-                        .current_frame
-                        .as_ref()
-                        .map(|(_, progress)| *progress)
-                        .unwrap_or_default()
+                if item.spritesheet_animation.progress != current_iterator_actual_progress {
+                    // User manually changed item.spritesheet_animation.progress
+                    if animation_instance
+                        .iterator
+                        .to(item.spritesheet_animation.progress)
+                    {
+                        Self::play_frame(&mut animation_instance.iterator, &mut item, event_writer)
+                            .inspect(|new_frame_data| {
+                                animation_instance.current_frame = Some(new_frame_data.clone());
+                                animation_instance.accumulated_time = Duration::ZERO;
+                            });
+                    } else {
+                        // Restore to the last valid progress if user set an invalid one
+                        item.spritesheet_animation.progress = current_iterator_actual_progress;
+                    }
                 }
             }
 
@@ -160,50 +195,71 @@ impl Animator {
                 time.delta_secs() * item.spritesheet_animation.speed_factor,
             );
 
-            while let Some(current_frame) = animation_instance
-                .current_frame
-                .as_ref()
-                .filter(|frame| animation_instance.accumulated_time > frame.0.duration)
-            {
-                // Consume the elapsed time
+            while let Some(cf_data_tuple) = animation_instance.current_frame.as_ref() {
+                let frame_duration = cf_data_tuple.0.duration;
 
-                animation_instance.accumulated_time -= current_frame.0.duration;
+                if animation_instance.accumulated_time >= frame_duration {
+                    // Check for zero duration frames to prevent potential infinite loops
+                    // if accumulated_time is also zero or doesn't advance.
+                    if frame_duration.is_zero() {
+                        // If frame_duration is zero, we must advance.
+                        // We don't subtract from accumulated_time to prevent it from getting stuck if it's also zero.
+                        // Or, log a warning and ensure progress.
+                        warn!(
+                            "Animation frame has zero duration for animation_id: {:?}, frame index: {:?}. Advancing.",
+                            animation_instance.animation_id, cf_data_tuple.1.frame
+                        );
+                        // No time subtraction, just move to next frame.
+                    } else {
+                        animation_instance.accumulated_time -= frame_duration;
+                    }
 
-                // Fetch the next frame
+                    // Store current frame info before advancing, for end events
+                    let last_played_frame_data = cf_data_tuple.0.clone(); // Clone IteratorFrame
 
-                animation_instance.current_frame =
-                    Self::play_frame(&mut animation_instance.iterator, &mut item, event_writer)
-                        .or_else(|| {
-                            // The animation is over
+                    // Fetch the next frame
 
-                            // Emit the end events if the animation just ended
+                    animation_instance.current_frame =
+                        Self::play_frame(&mut animation_instance.iterator, &mut item, event_writer)
+                            .or_else(|| {
+                                // The animation is over
 
-                            event_writer.send(AnimationEvent::ClipRepetitionEnd {
-                                entity: item.entity,
-                                animation_id: animation_instance.animation_id,
-                                clip_id: current_frame.0.clip_id,
-                                clip_repetition: current_frame.0.clip_repetition,
+                                // Emit the end events if the animation just ended
+
+                                event_writer.send(AnimationEvent::ClipRepetitionEnd {
+                                    entity: item.entity,
+                                    animation_id: animation_instance.animation_id,
+                                    clip_id: last_played_frame_data.clip_id,
+                                    clip_repetition: last_played_frame_data.clip_repetition,
+                                });
+
+                                event_writer.send(AnimationEvent::ClipEnd {
+                                    entity: item.entity,
+                                    animation_id: animation_instance.animation_id,
+                                    clip_id: last_played_frame_data.clip_id,
+                                });
+
+                                event_writer.send(AnimationEvent::AnimationRepetitionEnd {
+                                    entity: item.entity,
+                                    animation_id: animation_instance.animation_id,
+                                    animation_repetition: last_played_frame_data
+                                        .animation_repetition,
+                                });
+
+                                event_writer.send(AnimationEvent::AnimationEnd {
+                                    entity: item.entity,
+                                    animation_id: animation_instance.animation_id,
+                                });
+
+                                None
                             });
 
-                            event_writer.send(AnimationEvent::ClipEnd {
-                                entity: item.entity,
-                                animation_id: animation_instance.animation_id,
-                                clip_id: current_frame.0.clip_id,
-                            });
-
-                            event_writer.send(AnimationEvent::AnimationRepetitionEnd {
-                                entity: item.entity,
-                                animation_id: animation_instance.animation_id,
-                                animation_repetition: current_frame.0.animation_repetition,
-                            });
-
-                            event_writer.send(AnimationEvent::AnimationEnd {
-                                entity: item.entity,
-                                animation_id: animation_instance.animation_id,
-                            });
-
-                            None
-                        });
+                    if animation_instance.current_frame.is_none() {
+                        break; // Animation finished, exit while loop
+                    }
+                } else {
+                    break; // Not enough accumulated_time for the current frame
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #41 

Previous:

![animation](https://github.com/user-attachments/assets/ec21e23c-956b-48e4-a726-164a8c438a92)

Now:

![fix anim](https://github.com/user-attachments/assets/67c49cf6-1c2c-438d-838a-bb2544921a68)
