### PR TITLE
fix CursorIcon::Custom usage

### DIFF
--- a/examples/stress.rs
+++ b/examples/stress.rs
@@ -12,7 +12,7 @@
 #[path = "./common/mod.rs"]
 pub mod common;
 
-use bevy::{diagnostic::FrameTimeDiagnosticsPlugin, prelude::*};
+use bevy::prelude::*;
 use bevy_spritesheet_animation::prelude::*;
 use clap::{Parser, ValueEnum};
 use common::random_position;

--- a/src/animator.rs
+++ b/src/animator.rs
@@ -255,10 +255,12 @@ impl Animator {
                 .cursor_icon
                 .as_deref_mut()
                 .and_then(|cursor_icon| {
-                    if let CursorIcon::Custom(CustomCursor::Image {
-                        ref mut texture_atlas,
-                        ..
-                    }) = *cursor_icon
+                    if let CursorIcon::Custom(CustomCursor::Image(
+                        bevy::winit::cursor::CustomCursorImage {
+                            ref mut texture_atlas,
+                            ..
+                        },
+                    )) = *cursor_icon
                     {
                         Some(texture_atlas)
                     } else {


### PR DESCRIPTION
hey !
```
error[E0026]: variant `bevy::bevy_winit::cursor::CustomCursor::Image` does not have a field named `texture_atlas`
   --> src/animator.rs:259:33
    |
259 |                         ref mut texture_atlas,
    |                                 ^^^^^^^^^^^^^
    |                                 |
    |                                 variant `bevy::bevy_winit::cursor::CustomCursor::Image` does not have this field
    |                                 help: `bevy::bevy_winit::cursor::CustomCursor::Image` has a field named `0`
    ```