### PR TITLE
fix(dependencies): Update to bevy 0.19.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ custom_cursor = ["bevy/custom_cursor"]
 serde = ["dep:serde"]
 
 [dependencies]
-bevy = { version = "0.19.0-rc.1", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
   "bevy_log",
   "bevy_sprite",
   "bevy_ui",
@@ -55,7 +55,7 @@ required-features = ["custom_cursor"]
 
 [dev-dependencies]
 approx = "0.5.1"
-bevy = { version = "0.19.0-rc.1", features = [
+bevy = { version = "0.19.0", features = [
   # Needed for the "stress" example  as it uses Bevy's FPS overlay
   "bevy_dev_tools",
 ] }


### PR DESCRIPTION
Previously an rc has been used accidentally.

Also see:
https://github.com/merwaaan/bevy_spritesheet_animation/pull/73#issuecomment-4799106087

## Note

The only testing that was done is running:

```sh
cargo check --all-targets --all-features
```

This should most likely be enough since the upgrade from the rc should not introduce many problems.